### PR TITLE
Backend work/json

### DIFF
--- a/src/main/java/kr/ac/pknu/capstone/ApiController.java
+++ b/src/main/java/kr/ac/pknu/capstone/ApiController.java
@@ -2,12 +2,11 @@ package kr.ac.pknu.capstone;
 
 import kr.ac.pknu.capstone.domain.Data.Data;
 import kr.ac.pknu.capstone.service.DataService;
+import kr.ac.pknu.capstone.web.dto.UpdateRequestDto;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -25,9 +24,14 @@ public class ApiController {
 
     @GetMapping("query")
     public List<Data> query(
-            @RequestParam(value = "vCPU", defaultValue = "0") Integer vcpu, @RequestParam(value = "Memory", defaultValue = "0") Integer memory
+            @RequestParam(value = "vCPU", defaultValue = "0") int vCPU, @RequestParam(value = "Memory", defaultValue = "0") int memory
     ) throws Exception {
-        return dataService.find(vcpu, memory);
+        return dataService.find(vCPU, memory);
+    }
+
+    @PostMapping("update")
+    public void update(@RequestBody UpdateRequestDto updateRequestDto) throws Exception {
+        dataService.save(updateRequestDto);
     }
 
 }

--- a/src/main/java/kr/ac/pknu/capstone/ApiController.java
+++ b/src/main/java/kr/ac/pknu/capstone/ApiController.java
@@ -6,9 +6,7 @@ import kr.ac.pknu.capstone.web.dto.UpdateRequestDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
-import java.io.IOException;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("api")

--- a/src/main/java/kr/ac/pknu/capstone/ApiController.java
+++ b/src/main/java/kr/ac/pknu/capstone/ApiController.java
@@ -20,22 +20,14 @@ public class ApiController {
 
     @GetMapping("/")
     public List<Data> root() throws Exception {
-        // JPA로 옮기면 수정할 것
-        return dataService.readJsonData();
+        return dataService.findAll();
     }
 
     @GetMapping("query")
     public List<Data> query(
             @RequestParam(value = "vCPU", defaultValue = "0") Integer vcpu, @RequestParam(value = "Memory", defaultValue = "0") Integer memory
     ) throws Exception {
-
-        List<Data> data = dataService.readJsonData();
-
-        // TODO: 이 부분도 옮기기
-        return data.stream().filter(d ->
-                (vcpu.equals(0) || d.getVCPU().equals(vcpu)) && (memory.equals(0) || d.getMemory().equals(memory))
-        ).collect(Collectors.toList());
-
+        return dataService.find(vcpu, memory);
     }
 
 }

--- a/src/main/java/kr/ac/pknu/capstone/ApiController.java
+++ b/src/main/java/kr/ac/pknu/capstone/ApiController.java
@@ -18,7 +18,7 @@ public class ApiController {
     DataService dataService;
 
     @GetMapping("/")
-    public List<Data> root() throws Exception {
+    public List<Data> root() {
         return dataService.findAll();
     }
 
@@ -30,7 +30,7 @@ public class ApiController {
     }
 
     @PostMapping("update")
-    public void update(@RequestBody UpdateRequestDto updateRequestDto) throws Exception {
+    public void update(@RequestBody UpdateRequestDto updateRequestDto) {
         dataService.save(updateRequestDto);
     }
 

--- a/src/main/java/kr/ac/pknu/capstone/domain/Data/Data.java
+++ b/src/main/java/kr/ac/pknu/capstone/domain/Data/Data.java
@@ -25,7 +25,7 @@ public class Data {
     private String type;
 
     @JsonProperty("vCPU")
-    private Integer vCPU;
+    private Integer vcpu;
 
     @JsonProperty("Memory(GiB)")
     private Integer memory;

--- a/src/main/java/kr/ac/pknu/capstone/domain/Data/Data.java
+++ b/src/main/java/kr/ac/pknu/capstone/domain/Data/Data.java
@@ -2,39 +2,41 @@ package kr.ac.pknu.capstone.domain.Data;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 @Getter
 public class Data {
 
     @JsonProperty("Vender")
-    private String Vendor;
+    private String vendor;
 
     @JsonProperty("Name")
-    private String Name;
+    private String name;
 
     @JsonProperty("I/O")
-    private String IO;
+    private String io;
 
     @JsonProperty("Type")
-    private String Type;
+    private String type;
 
     @JsonProperty("vCPU")
     private Integer vCPU;
 
     @JsonProperty("Memory(GiB)")
-    private Integer Memory;
+    private Integer memory;
 
     @JsonProperty("Currency exchange rates")
-    private String CurrencyExchangeRates;
+    private String currencyExchangeRates;
 
     @JsonProperty("Cost per hour")
-    private Integer CostPerHour;
+    private Integer costPerHour;
 
     @JsonProperty("etc")
-    private String Etc;
+    private String etc;
 
 }

--- a/src/main/java/kr/ac/pknu/capstone/domain/Data/DataRepository.java
+++ b/src/main/java/kr/ac/pknu/capstone/domain/Data/DataRepository.java
@@ -2,7 +2,6 @@ package kr.ac.pknu.capstone.domain.Data;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Repository;
 
@@ -13,24 +12,25 @@ import java.util.List;
 @Repository
 public class DataRepository {
 
-    @Autowired
-    ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
+    private final List<Data> data;
 
-    List<Data> data;
+    public DataRepository(ObjectMapper objectMapper) throws IOException {
+        this.objectMapper = objectMapper;
+        this.data = readJsonData();
+    }
 
-    private void readJsonData() throws IOException {
+    private List<Data> readJsonData() throws IOException {
         ClassPathResource resource = new ClassPathResource("data.json");
         File file = resource.getFile();
-        data = objectMapper.readValue(file, new TypeReference<List<Data>>() {});
+        return objectMapper.readValue(file, new TypeReference<List<Data>>() {});
     }
 
     public List<Data> findAll() throws IOException {
-        if(data == null) readJsonData();
         return data;
     }
 
     public void save(Data d) throws IOException {
-        if(data == null) readJsonData();
         data.add(d);
     }
 

--- a/src/main/java/kr/ac/pknu/capstone/domain/Data/DataRepository.java
+++ b/src/main/java/kr/ac/pknu/capstone/domain/Data/DataRepository.java
@@ -39,11 +39,11 @@ public class DataRepository {
 
     }
 
-    public List<Data> findAll() throws IOException {
+    public List<Data> findAll() {
         return data;
     }
 
-    public void save(Data d) throws IOException {
+    public void save(Data d) {
         data.add(d);
     }
 

--- a/src/main/java/kr/ac/pknu/capstone/domain/Data/DataRepository.java
+++ b/src/main/java/kr/ac/pknu/capstone/domain/Data/DataRepository.java
@@ -6,7 +6,9 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Repository;
 
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.List;
 
 @Repository
@@ -24,6 +26,17 @@ public class DataRepository {
         ClassPathResource resource = new ClassPathResource("data.json");
         File file = resource.getFile();
         return objectMapper.readValue(file, new TypeReference<List<Data>>() {});
+    }
+
+    private void saveJsonData() throws Exception {
+
+        // TODO: 테스트코드 작성해서 작동 확인 후 save에 추가하기
+        ClassPathResource resource = new ClassPathResource("data.json");
+        File file = resource.getFile();
+        FileWriter writer = new FileWriter(file, false);
+        writer.write(objectMapper.writeValueAsString(data));
+        writer.close();
+
     }
 
     public List<Data> findAll() throws IOException {

--- a/src/main/java/kr/ac/pknu/capstone/domain/Data/DataRepository.java
+++ b/src/main/java/kr/ac/pknu/capstone/domain/Data/DataRepository.java
@@ -30,6 +30,7 @@ public class DataRepository {
     private void saveJsonData() throws Exception {
 
         // TODO: 테스트코드 작성해서 작동 확인 후 save에 추가하기
+        // 테스트코드에서는 vendor를 'test'로 하고, afterEach에서 제거해주기
         ClassPathResource resource = new ClassPathResource("data.json");
         File file = resource.getFile();
         FileWriter writer = new FileWriter(file, false);

--- a/src/main/java/kr/ac/pknu/capstone/domain/Data/DataRepository.java
+++ b/src/main/java/kr/ac/pknu/capstone/domain/Data/DataRepository.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Repository;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.List;
 
 @Repository

--- a/src/main/java/kr/ac/pknu/capstone/domain/Data/DataRepository.java
+++ b/src/main/java/kr/ac/pknu/capstone/domain/Data/DataRepository.java
@@ -1,0 +1,37 @@
+package kr.ac.pknu.capstone.domain.Data;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Repository;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+@Repository
+public class DataRepository {
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    List<Data> data;
+
+    private void readJsonData() throws IOException {
+        ClassPathResource resource = new ClassPathResource("data.json");
+        File file = resource.getFile();
+        data = objectMapper.readValue(file, new TypeReference<List<Data>>() {});
+    }
+
+    public List<Data> findAll() throws IOException {
+        if(data == null) readJsonData();
+        return data;
+    }
+
+    public void save(Data d) throws IOException {
+        if(data == null) readJsonData();
+        data.add(d);
+    }
+
+}

--- a/src/main/java/kr/ac/pknu/capstone/service/DataService.java
+++ b/src/main/java/kr/ac/pknu/capstone/service/DataService.java
@@ -22,18 +22,18 @@ public class DataService {
 
     private final DataRepository dataRepository;
 
-    public List<Data> findAll() throws IOException {
+    public List<Data> findAll() {
         return dataRepository.findAll();
     }
 
-    public List<Data> find(int vCPU, int memory) throws IOException {
+    public List<Data> find(int vCPU, int memory) {
         // TODO: 이것도 옮기기
         return dataRepository.findAll().stream().filter(d ->
                 (vCPU == 0 || d.getVcpu().equals(vCPU)) && ( memory == 0 || d.getMemory().equals(memory))
         ).collect(Collectors.toList());
     }
 
-    public void save(UpdateRequestDto updateRequestDto) throws IOException {
+    public void save(UpdateRequestDto updateRequestDto) {
         dataRepository.save(updateRequestDto.toEntity());
     }
 

--- a/src/main/java/kr/ac/pknu/capstone/service/DataService.java
+++ b/src/main/java/kr/ac/pknu/capstone/service/DataService.java
@@ -1,17 +1,11 @@
 package kr.ac.pknu.capstone.service;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.ac.pknu.capstone.domain.Data.Data;
 import kr.ac.pknu.capstone.domain.Data.DataRepository;
 import kr.ac.pknu.capstone.web.dto.UpdateRequestDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/kr/ac/pknu/capstone/service/DataService.java
+++ b/src/main/java/kr/ac/pknu/capstone/service/DataService.java
@@ -3,6 +3,7 @@ package kr.ac.pknu.capstone.service;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.ac.pknu.capstone.domain.Data.Data;
+import kr.ac.pknu.capstone.web.dto.UpdateRequestDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
@@ -35,8 +36,13 @@ public class DataService {
     public List<Data> find(int vCPU, int memory) throws IOException {
         if(data == null) readJsonData();
         return data.stream().filter(d ->
-                (vCPU == 0 || d.getVCPU().equals(vCPU)) && ( memory == 0 || d.getMemory().equals(memory))
+                (vCPU == 0 || d.getVcpu().equals(vCPU)) && ( memory == 0 || d.getMemory().equals(memory))
         ).collect(Collectors.toList());
+    }
+
+    public void save(UpdateRequestDto updateRequestDto) throws IOException {
+        if(data == null) readJsonData();
+        data.add(updateRequestDto.toEntity());
     }
 
 }

--- a/src/main/java/kr/ac/pknu/capstone/service/DataService.java
+++ b/src/main/java/kr/ac/pknu/capstone/service/DataService.java
@@ -32,10 +32,10 @@ public class DataService {
         return data;
     }
 
-    public List<Data> find(int vcpu, int memory) throws IOException {
+    public List<Data> find(int vCPU, int memory) throws IOException {
         if(data == null) readJsonData();
         return data.stream().filter(d ->
-                (vcpu == 0 || d.getVCPU().equals(vcpu)) && ( memory == 0 || d.getMemory().equals(memory))
+                (vCPU == 0 || d.getVCPU().equals(vCPU)) && ( memory == 0 || d.getMemory().equals(memory))
         ).collect(Collectors.toList());
     }
 

--- a/src/main/java/kr/ac/pknu/capstone/service/DataService.java
+++ b/src/main/java/kr/ac/pknu/capstone/service/DataService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.stream.Collectors;
 
 
 @Service
@@ -18,10 +19,24 @@ public class DataService {
     @Autowired
     ObjectMapper objectMapper;
 
-    public List<Data> readJsonData() throws IOException {
+    List<Data> data;
+
+    private void readJsonData() throws IOException {
         ClassPathResource resource = new ClassPathResource("data.json");
         File file = resource.getFile();
-        return objectMapper.readValue(file, new TypeReference<List<Data>>() {});
+        data = objectMapper.readValue(file, new TypeReference<List<Data>>() {});
+    }
+
+    public List<Data> findAll() throws IOException {
+        if(data == null) readJsonData();
+        return data;
+    }
+
+    public List<Data> find(int vcpu, int memory) throws IOException {
+        if(data == null) readJsonData();
+        return data.stream().filter(d ->
+                (vcpu == 0 || d.getVCPU().equals(vcpu)) && ( memory == 0 || d.getMemory().equals(memory))
+        ).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/kr/ac/pknu/capstone/service/DataService.java
+++ b/src/main/java/kr/ac/pknu/capstone/service/DataService.java
@@ -3,7 +3,9 @@ package kr.ac.pknu.capstone.service;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.ac.pknu.capstone.domain.Data.Data;
+import kr.ac.pknu.capstone.domain.Data.DataRepository;
 import kr.ac.pknu.capstone.web.dto.UpdateRequestDto;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
@@ -15,34 +17,24 @@ import java.util.stream.Collectors;
 
 
 @Service
+@RequiredArgsConstructor
 public class DataService {
 
-    @Autowired
-    ObjectMapper objectMapper;
-
-    List<Data> data;
-
-    private void readJsonData() throws IOException {
-        ClassPathResource resource = new ClassPathResource("data.json");
-        File file = resource.getFile();
-        data = objectMapper.readValue(file, new TypeReference<List<Data>>() {});
-    }
+    private final DataRepository dataRepository;
 
     public List<Data> findAll() throws IOException {
-        if(data == null) readJsonData();
-        return data;
+        return dataRepository.findAll();
     }
 
     public List<Data> find(int vCPU, int memory) throws IOException {
-        if(data == null) readJsonData();
-        return data.stream().filter(d ->
+        // TODO: 이것도 옮기기
+        return dataRepository.findAll().stream().filter(d ->
                 (vCPU == 0 || d.getVcpu().equals(vCPU)) && ( memory == 0 || d.getMemory().equals(memory))
         ).collect(Collectors.toList());
     }
 
     public void save(UpdateRequestDto updateRequestDto) throws IOException {
-        if(data == null) readJsonData();
-        data.add(updateRequestDto.toEntity());
+        dataRepository.save(updateRequestDto.toEntity());
     }
 
 }

--- a/src/main/java/kr/ac/pknu/capstone/web/dto/UpdateRequestDto.java
+++ b/src/main/java/kr/ac/pknu/capstone/web/dto/UpdateRequestDto.java
@@ -16,7 +16,7 @@ public class UpdateRequestDto {
     private String name;
     private String io;
     private String type;
-    private Integer vCPU;
+    private Integer vcpu;
     private Integer memory;
     private String currencyExchangeRates;
     private Integer costPerHour;
@@ -28,7 +28,7 @@ public class UpdateRequestDto {
                 .name(name)
                 .io(io)
                 .type(type)
-                .vCPU(vCPU)
+                .vcpu(vcpu)
                 .memory(memory)
                 .currencyExchangeRates(currencyExchangeRates)
                 .costPerHour(costPerHour)

--- a/src/main/java/kr/ac/pknu/capstone/web/dto/UpdateRequestDto.java
+++ b/src/main/java/kr/ac/pknu/capstone/web/dto/UpdateRequestDto.java
@@ -1,0 +1,39 @@
+package kr.ac.pknu.capstone.web.dto;
+
+import kr.ac.pknu.capstone.domain.Data.Data;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdateRequestDto {
+
+    private String vendor;
+    private String name;
+    private String io;
+    private String type;
+    private Integer vCPU;
+    private Integer memory;
+    private String currencyExchangeRates;
+    private Integer costPerHour;
+    private String etc;
+
+    public Data toEntity() {
+        return Data.builder()
+                .vendor(vendor)
+                .name(name)
+                .io(io)
+                .type(type)
+                .vCPU(vCPU)
+                .memory(memory)
+                .currencyExchangeRates(currencyExchangeRates)
+                .costPerHour(costPerHour)
+                .etc(etc)
+                .build();
+    }
+
+}

--- a/src/test/java/kr/ac/pknu/capstone/ApiControllerTest.java
+++ b/src/test/java/kr/ac/pknu/capstone/ApiControllerTest.java
@@ -1,5 +1,9 @@
 package kr.ac.pknu.capstone;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.ac.pknu.capstone.domain.Data.Data;
+import kr.ac.pknu.capstone.web.dto.UpdateRequestDto;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,10 +14,17 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -24,6 +35,9 @@ public class ApiControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @DisplayName("api에서 json데이터를 잘 넘기는지 확인")
     @Test
@@ -49,13 +63,53 @@ public class ApiControllerTest {
     @Test
     public void queryTest() throws Exception {
 
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("vCPU", "4");
+
         mockMvc.perform(
-                get("/api/query").param("vCPU", "4")
+                get("/api/query").params(params)
         )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$").isArray())
                 .andExpect(jsonPath("$[*].vCPU", everyItem(is(4))))
                 .andDo(MockMvcRestDocumentation.document("api/query"));
+
+    }
+
+    @DisplayName("update 작동 확인")
+    @Test
+    public void updateTest() throws Exception {
+
+        UpdateRequestDto updateRequestDto = new UpdateRequestDto(
+                "vendor",
+                "name",
+                "io",
+                "type",
+                1,
+                1,
+                "rate",
+                1,
+                "etc"
+        );
+
+        mockMvc.perform(
+                        post("/api/update")
+                                .content(objectMapper.writeValueAsString(updateRequestDto))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk());
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("vCPU", "1");
+        params.add("memory", "1");
+
+        // TODO: 여기서 터지는데 확인하고 고치기
+        mockMvc.perform(
+                        get("/api/query").params(params)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[-1].Vender", is("vendor")));
 
     }
 

--- a/src/test/java/kr/ac/pknu/capstone/ApiControllerTest.java
+++ b/src/test/java/kr/ac/pknu/capstone/ApiControllerTest.java
@@ -1,9 +1,7 @@
 package kr.ac.pknu.capstone;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import kr.ac.pknu.capstone.domain.Data.Data;
 import kr.ac.pknu.capstone.web.dto.UpdateRequestDto;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,10 +14,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.is;

--- a/src/test/java/kr/ac/pknu/capstone/service/DataServiceTest.java
+++ b/src/test/java/kr/ac/pknu/capstone/service/DataServiceTest.java
@@ -43,12 +43,12 @@ public class DataServiceTest {
 
         Integer vcpu = 2, memory = 4;
         List<Data> res = data.stream().filter(d ->
-                (vcpu.equals(0) || d.getVCPU().equals(vcpu)) && (memory.equals(0) || d.getMemory().equals(memory))
+                (vcpu.equals(0) || d.getVcpu().equals(vcpu)) && (memory.equals(0) || d.getMemory().equals(memory))
         ).collect(Collectors.toList());
 
         Assertions.assertThat(res)
                 .isNotEmpty()
-                .allMatch(d -> d.getVCPU().equals(vcpu) && d.getMemory().equals(memory));
+                .allMatch(d -> d.getVcpu().equals(vcpu) && d.getMemory().equals(memory));
 
     }
 


### PR DESCRIPTION
json을 계속 사용하는 브랜치

DataService에서 json을 인메모리로 관리하게 했습니다. 지금 생각해보니 이 부분은 레포지토리로 분리하는 게 맞는 것 같네요
이제 api/update로 데이터 들어오면 data.json에 저장하게 하면 만들고자 하는 기능은 완성될 것 같습니다.

확인 차 풀리퀘 올려둡니다. 원하시는 작업이 아니라면 말씀해주세요

TODO
---
- [x] 서비스에서 레포지토리 코드 분리하기
- [ ] 데이터 추가 시 저장이 이루어지게 하기